### PR TITLE
fix #17

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -55,7 +55,7 @@ module.exports = NodeHelper.create({
 	 */
 	getSensorData: function(payload) {
 		var self = this;
-		exec("sudo " + payload.scriptPath + " " + payload.sensorPin + " -m j -a 3", {}, function(error, stdout, stderr){
+		exec(payload.scriptPath + " " + payload.sensorPin + " -m j -a 3", {}, function(error, stdout, stderr){
 			var result;
 			if (!error) {
 				result = { original: payload, isSuccessful: true, data: JSON.parse(stdout) };


### PR DESCRIPTION
also sudo should not be necessary to simply read a sensor.

It should also not be necessary because it will run into errors when Magicmirror is not executed as sudo (due to possible password question) and secondly because if magicMirror is already running as sudo than you don't need another.